### PR TITLE
ci: add manual trigger + probe workflow for trigger diagnosis

### DIFF
--- a/.github/workflows/ci-probe.yml
+++ b/.github/workflows/ci-probe.yml
@@ -1,0 +1,20 @@
+name: CI Probe
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  probe:
+    name: Probe Trigger
+    runs-on: ubuntu-latest
+    steps:
+      - name: Print event context
+        run: |
+          echo "event=${{ github.event_name }}"
+          echo "ref=${{ github.ref }}"
+          echo "sha=${{ github.sha }}"
+          echo "actor=${{ github.actor }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/onboarding-test.yml
+++ b/.github/workflows/onboarding-test.yml
@@ -10,6 +10,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   onboarding-test:


### PR DESCRIPTION
## Why
Push/PR-triggered GitHub Actions runs are not appearing on this fork even though workflows are active.

## Changes
- add `workflow_dispatch` to `CI` so the main CI gate can be run manually
- add lightweight `CI Probe` workflow to verify trigger path (`push`, `pull_request`, `workflow_dispatch`)

## Validation
- this PR should itself create a `pull_request` run for `CI Probe` if trigger path is healthy
- if not, we can still manually dispatch both workflows and inspect logs